### PR TITLE
T1T HR0 and HR1 parameters missing in tag dectection

### DIFF
--- a/src/nfa/dm/nfa_dm_act.c
+++ b/src/nfa/dm/nfa_dm_act.c
@@ -1779,8 +1779,18 @@ void nfa_dm_notify_activation_status (tNFA_STATUS status, tNFA_TAG_PARAMS *p_par
         /* get length of NFCID and location */
         if (p_tech_params->mode == NFC_DISCOVERY_TYPE_POLL_A)
         {
-            nfcid_len = p_tech_params->param.pa.nfcid1_len;
-            p_nfcid   = p_tech_params->param.pa.nfcid1;
+            if ((p_tech_params->param.pa.nfcid1_len == 0) && (p_params != NULL))
+            {
+                nfcid_len = sizeof(p_params->t1t.uid);
+                p_nfcid   = p_params->t1t.uid;
+                evt_data.activated.activate_ntf.rf_tech_param.param.pa.nfcid1_len = nfcid_len;
+                memcpy (evt_data.activated.activate_ntf.rf_tech_param.param.pa.nfcid1, p_nfcid, nfcid_len);
+            }
+            else
+            {
+                nfcid_len = p_tech_params->param.pa.nfcid1_len;
+                p_nfcid   = p_tech_params->param.pa.nfcid1;
+            }
         }
         else if (p_tech_params->mode == NFC_DISCOVERY_TYPE_POLL_B)
         {

--- a/src/nfa/rw/nfa_rw_act.c
+++ b/src/nfa/rw/nfa_rw_act.c
@@ -275,6 +275,7 @@ static void nfa_rw_handle_ndef_detect(tRW_EVENT event, tRW_DATA *p_rw_data)
                 conn_evt_data.ndef_detect.cur_size = 0;
                 conn_evt_data.ndef_detect.max_size = 0;
                 conn_evt_data.ndef_detect.flags    = RW_NDEF_FL_UNKNOWN;
+                conn_evt_data.ndef_detect.status   = NFA_STATUS_TIMEOUT;
             }
             else
             {
@@ -548,11 +549,41 @@ void nfa_rw_handle_presence_check_rsp (tNFC_STATUS status)
 static void nfa_rw_handle_t1t_evt (tRW_EVENT event, tRW_DATA *p_rw_data)
 {
     tNFA_CONN_EVT_DATA conn_evt_data;
+    tNFA_TAG_PARAMS tag_params;
+    UINT8 *p_rid_rsp;
+    tNFA_STATUS activation_status;
 
     conn_evt_data.status = p_rw_data->data.status;
     switch (event)
     {
     case RW_T1T_RID_EVT:
+        if (p_rw_data->data.p_data != NULL)
+        {
+            /* Assume the data is just the response byte sequence */
+            p_rid_rsp = (UINT8 *)(p_rw_data->data.p_data + 1) + p_rw_data->data.p_data->offset;
+            /* Fetch HR from RID response message */
+            STREAM_TO_ARRAY (tag_params.t1t.hr, p_rid_rsp, T1T_HR_LEN);
+            /* Fetch UID0-3 from RID response message */
+            STREAM_TO_ARRAY (tag_params.t1t.uid, p_rid_rsp, T1T_CMD_UID_LEN);
+            GKI_freebuf (p_rw_data->data.p_data);
+            p_rw_data->data.p_data = NULL;
+        }
+
+        /* Command complete - perform cleanup, notify the app */
+        nfa_rw_command_complete();
+
+        if (p_rw_data->status == NFC_STATUS_TIMEOUT)
+        {
+            activation_status = NFA_STATUS_TIMEOUT;
+        }
+        else
+        {
+            activation_status = NFA_STATUS_OK;
+        }
+
+        nfa_dm_notify_activation_status (activation_status, &tag_params);
+        break;
+
     case RW_T1T_RALL_CPLT_EVT:
     case RW_T1T_READ_CPLT_EVT:
     case RW_T1T_RSEG_CPLT_EVT:
@@ -2550,6 +2581,9 @@ BOOLEAN nfa_rw_activate_ntf(tNFA_RW_MSG *p_data)
         /* Retrieve HR and UID fields from activation notification */
         memcpy (tag_params.t1t.hr, p_activate_params->intf_param.intf_param.frame.param, NFA_T1T_HR_LEN);
         memcpy (tag_params.t1t.uid, p_activate_params->rf_tech_param.param.pa.nfcid1, p_activate_params->rf_tech_param.param.pa.nfcid1_len);
+        msg.op = NFA_RW_OP_T1T_RID;
+        nfa_rw_handle_op_req ((tNFA_RW_MSG *)&msg);
+        activate_notify = FALSE;                    /* Delay notifying upper layer of NFA_ACTIVATED_EVT until HR0/HR1 is received */
         break;
 
     case NFC_PROTOCOL_T2T:

--- a/src/nfc/tags/rw_t1t_ndef.c
+++ b/src/nfc/tags/rw_t1t_ndef.c
@@ -2200,7 +2200,7 @@ static void rw_t1t_update_lock_attributes (void)
                     {
                         /* Set/clear lock_attr byte bits based on whether a particular lock bit is set or not
                          * each bit in lock_attr represents one byte in Tag read only attribute */
-                        if (p_t1t->lockbyte[num_dynamic_lock_bytes].lock_byte & rw_t1t_mask_bits[xx])
+                        if ((p_t1t->lockbyte[num_dynamic_lock_bytes].lock_byte & rw_t1t_mask_bits[xx]) && (block_count < T1T_BLOCKS_PER_SEGMENT))
                         {
                             p_t1t->lock_attr[block_count] |= 0x01 << bits_covered;
                         }


### PR DESCRIPTION
There should be RID command to get HR0 and HR1 parameters. This patch adds RID to fix this problem.

Change-Id: I88d901ce204eb1bb8ba72702396f536282bfa65c
